### PR TITLE
fix: 캘린더 탭에서 상태바를 탭해서 달력을 최상단으로 스크롤하는 동작 방지

### DIFF
--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -187,4 +187,9 @@ extension CalendarViewController: UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         scrollManager.handleScrollForInfiniteLoading(scrollView)
     }
+
+    /// 상단바를 탭해서 최상단으로 스크롤하는 동작 방지
+    func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+        return false
+    }
 }


### PR DESCRIPTION
## 작업내용
- 기존에 캘린더 탭에서 상태바를 탭하면 최상단으로 스크롤할 수 있었습니다.
- 하지만 다른 탭을 갔다가 캘린더 탭에 와서 상태바를 탭하는 경우, 달력이 추가로 로드가 되지 않는 문제가 있습니다.
- 프로젝트 기간상 임시로 상태바 탭을 막도록 처리했습니다.

## 테스트
- 캘린더 탭에서 상태바 탭 시 스크롤 되지 않음

## 링크
- [노션 태스크](https://www.notion.so/oreumi/253ebaa8982b80b785dee9bc72f631b0?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)