### PR TITLE
fix: 대시보드 탭에서 패드 화면 회전시 scrollManager 관련 크래시 수정

### DIFF
--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -52,7 +52,7 @@ final class CalendarViewController: CoreGradientViewController {
         // 이 경우, scrollManager는 아직 초기화되지 않았기 때문에 강제 접근 시 crash 발생 가능
         // 따라서 "뷰가 이미 로드되고 실제 화면(window)에 표시된 경우"에만
         // scrollManager.handleDeviceRotation()을 호출하도록 제한.
-        guard isViewLoaded && view.window != nil else { return }
+        guard viewIfLoaded?.window != nil else { return }
         scrollManager.handleDeviceRotation(coordinator: coordinator)
     }
 }


### PR DESCRIPTION
## 작업내용
- 캘린더 탭을 들리지 않고 대시보드 탭에서 패드의 화면 회전할 경우,
  scrollManager와 관련해 Fatal Error가 발생하여 이를 수정합니다.
  ```
  Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
  ```

## 테스트
- 아이패드에서 메인화면 진입하자마자 화면 회전시 크래시 발생 X

## 링크
- [노션 태스크](https://www.notion.so/oreumi/scrollManager-253ebaa8982b8072bf43feac51199a3a?v=241ebaa8982b807d8175000ce30f2bd1&source=copy_link)