### PR TITLE
fix: 아이패드로 캘린더탭에서 화면회전시 달력 스크롤 위치 문제 수정

### DIFF
--- a/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
+++ b/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
@@ -140,7 +140,7 @@ private extension CalendarScrollManager {
     /// 완전히 보이는 셀이 없는 경우, 부분적으로라도 보이는 셀 중에서 선택합니다.
     ///
     /// - Returns: 현재 화면에서 보이는 월 데이터. 유효한 셀이 없는 경우 `nil`
-    private func getLastSeenMonthData() -> CalendarMonthData? {
+    func getLastSeenMonthData() -> CalendarMonthData? {
         guard let collectionView,
               let calendarVM else { return nil }
 


### PR DESCRIPTION
## 작업내용
- 아이패드로 캘린더탭에서 가로/세로 회전시, 간헐적으로 비정상적인 위치로 스크롤되는 문제를 수정합니다.

## 링크
- [노션 태스크](https://www.notion.so/oreumi/255ebaa8982b80da89d1fe203532d226?source=copy_link)