### PR TITLE
fix: CalendarVC의 deinit에서 크래시나는 문제 수정

### DIFF
--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -55,6 +55,7 @@ final class CalendarViewController: HealthNavigationController, Alertable {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         // 뷰 컨트롤러가 완전히 제거될 때
         if isMovingFromParent || isBeingDismissed {
             dataManager.stopObserving()


### PR DESCRIPTION
## 작업내용
- CalendarViewController의 deinit에서 크래시가 발생해서
  해당 로직을 viewWillDisappear()로 옮겼습니다.

## 테스트
- 다른 탭 갔다와도 무한스크롤 재동작 확인