### PR TITLE
feat: 현재 활성화된 탭을 한 번 더 탭하면 최상단으로 스크롤 (달력은 현재월로 이동)

### DIFF
--- a/Health/Core/Protocols/ScrollableToTop.swift
+++ b/Health/Core/Protocols/ScrollableToTop.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// 탭바에서 같은 탭 재선택 시 최상단으로 스크롤하는 기능을 제공하는 프로토콜
+protocol ScrollableToTop {
+    /// 뷰를 최상단으로 스크롤합니다.
+    func scrollToTop()
+}

--- a/Health/Core/ViewControllers/HealthTabBarController.swift
+++ b/Health/Core/ViewControllers/HealthTabBarController.swift
@@ -11,13 +11,26 @@ final class HealthTabBarController: UITabBarController {
 
     private let tabHeight: CGFloat = 94
 
+    private var previousSelectedIndex = 0
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.delegate = self
         configureTabBarAppearance()
+        setPreviousSelectedIndex(selectedIndex)
     }
 
-    private func configureTabBarAppearance() {
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        self.tabBar.frame.size.height = tabHeight
+        self.tabBar.frame.origin.y = view.frame.height - tabHeight
+    }
+}
+
+private extension HealthTabBarController {
+
+    func configureTabBarAppearance() {
         let appearance = UITabBarAppearance()
 
         appearance.configureWithTransparentBackground()
@@ -35,20 +48,32 @@ final class HealthTabBarController: UITabBarController {
         self.tabBar.scrollEdgeAppearance = appearance
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        self.tabBar.frame.size.height = tabHeight
-        self.tabBar.frame.origin.y = view.frame.height - tabHeight
+    func setPreviousSelectedIndex(_ index: Int) {
+        previousSelectedIndex = index
     }
 }
 
 extension HealthTabBarController: UITabBarControllerDelegate {
+
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        if let nav = viewController as? UINavigationController,
-           let calendarVC = nav.viewControllers.first as? CalendarViewController {
-            /// 캘린더 탭이 선택된 경우 현재 월로 스크롤하도록 설정
-            calendarVC.shouldScrollToCurrentOnAppear = true
+        guard let nav = viewController as? UINavigationController,
+              let topVC = nav.viewControllers.first else { return }
+
+        let currentSelectedIndex = selectedIndex
+
+        // 같은 탭을 다시 탭한 경우 (이전 인덱스와 현재 인덱스가 같음)
+        if previousSelectedIndex == currentSelectedIndex {
+            // 뷰가 로드된 상태에서만 스크롤 동작 실행
+            guard topVC.isViewLoaded else { return }
+
+            if let scrollableVC = topVC as? ScrollableToTop {
+                scrollableVC.scrollToTop()
+            } else if let calendarVC = topVC as? CalendarViewController {
+                calendarVC.scrollToCurrentMonth()
+            }
         }
+
+        // 현재 선택된 탭을 이전 탭으로 업데이트
+        previousSelectedIndex = currentSelectedIndex
     }
 }

--- a/Health/Core/ViewControllers/HealthTabBarController.swift
+++ b/Health/Core/ViewControllers/HealthTabBarController.swift
@@ -74,6 +74,6 @@ extension HealthTabBarController: UITabBarControllerDelegate {
         }
 
         // 현재 선택된 탭을 이전 탭으로 업데이트
-        previousSelectedIndex = currentSelectedIndex
+        setPreviousSelectedIndex(currentSelectedIndex)
     }
 }

--- a/Health/Presentation/Calendar/CalendarViewController.swift
+++ b/Health/Presentation/Calendar/CalendarViewController.swift
@@ -8,14 +8,6 @@ final class CalendarViewController: HealthNavigationController, Alertable {
 
     @IBOutlet weak var collectionView: UICollectionView!
 
-    /// 뷰가 나타날 때 현재 월로 스크롤할지 여부를 결정하는 플래그
-    ///
-    /// 탭 전환 시(`true`)와 화면 내 네비게이션(`false`) 시나리오를 구분하여 적절한 스크롤 동작을 제어합니다.
-    /// `viewWillAppear(_:)`에서 사용된 후 자동으로 `false`로 리셋되어 일회성 동작을 보장합니다.
-    ///
-    /// - Note: 다른 탭에서 달력 탭으로 전환할 때만 `true`로 설정하고, 달력 내 push/pop 시에는 기본값(`false`)을 유지합니다.
-    var shouldScrollToCurrentOnAppear = false
-
     private let calendarVM = CalendarViewModel()
     private lazy var dataManager = CalendarDataManager(calendarVM: calendarVM, collectionView: collectionView)
     private lazy var scrollManager = CalendarScrollManager(calendarVM: calendarVM, collectionView: collectionView)
@@ -34,12 +26,6 @@ final class CalendarViewController: HealthNavigationController, Alertable {
         configureNavigationBar()
 		configureBackground()
         configureCollectionView()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        scrollManager.handleViewWillAppear(shouldScrollToCurrentOnAppear)
-        shouldScrollToCurrentOnAppear = false // 기본값으로 복원
     }
 
     override func viewDidLayoutSubviews() {
@@ -65,6 +51,12 @@ final class CalendarViewController: HealthNavigationController, Alertable {
         if isMovingFromParent || isBeingDismissed {
             dataManager.stopObserving()
         }
+    }
+
+    // 캘린더 탭 재선택 시 현재 월로 스크롤
+    func scrollToCurrentMonth() {
+        guard isViewLoaded, collectionView != nil else { return }
+        scrollManager.scrollToCurrentMonth(animated: true)
     }
 }
 
@@ -114,7 +106,7 @@ private extension CalendarViewController {
         let scrollToCurrentButton = HealthBarButtonItem(
             image: UIImage(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90"),
             primaryAction: { [weak self] in
-                self?.scrollManager.scrollToCurrentMonth(animated: true)
+                self?.scrollToCurrentMonth()
             }
         )
 

--- a/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
+++ b/Health/Presentation/Calendar/Managers/CalendarScrollManager.swift
@@ -44,21 +44,6 @@ final class CalendarScrollManager {
         }
     }
 
-    /// `viewWillAppear`에서 호출되는 메서드
-    ///
-    /// 탭 전환 시나리오에 따라 적절한 스크롤 동작을 수행합니다.
-    ///
-    /// - Parameter shouldScrollToCurrent: 현재 월로 스크롤할지 여부
-    ///   - `true`: 다른 탭에서 캘린더 탭으로 진입 시 (현재 월로 스크롤)
-    ///   - `false`: 캘린더 탭 내에서 push/pop 복귀 시 (스크롤 위치 유지)
-    func handleViewWillAppear(_ shouldScrollToCurrent: Bool) {
-        if shouldScrollToCurrent {
-            scrollToCurrentMonth()
-        } else {
-            return
-        }
-    }
-
     /// 현재 월로 스크롤합니다.
     func scrollToCurrentMonth(animated: Bool = false) {
         guard let collectionView = collectionView,

--- a/Health/Presentation/Dashboard/DashboardViewController.swift
+++ b/Health/Presentation/Dashboard/DashboardViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import TSAlertController
 
-final class DashboardViewController: HealthNavigationController, Alertable {
+final class DashboardViewController: HealthNavigationController, Alertable, ScrollableToTop {
 
     typealias DashboardDiffableDataSource = UICollectionViewDiffableDataSource<DashboardContent.Section, DashboardContent.Item>
 
@@ -39,6 +39,11 @@ final class DashboardViewController: HealthNavigationController, Alertable {
         buildLayout()
         setupDataSource()
         applySnapshot()
+    }
+
+    func scrollToTop() {
+        guard isViewLoaded, dashboardCollectionView != nil else { return }
+        dashboardCollectionView.setContentOffset(.zero, animated: true)
     }
 
     private func buildLayout() {

--- a/Health/Presentation/Personal/PersonalViewController.swift
+++ b/Health/Presentation/Personal/PersonalViewController.swift
@@ -9,7 +9,7 @@ import CoreLocation
 import Combine
 import TSAlertController
 
-class PersonalViewController: HealthNavigationController, Alertable, UICollectionViewDelegate {
+class PersonalViewController: HealthNavigationController, Alertable, ScrollableToTop, UICollectionViewDelegate {
 
     typealias PersonalDiffableDataSource = UICollectionViewDiffableDataSource<PersonalContent.Section, PersonalContent.Item>
 
@@ -87,6 +87,11 @@ class PersonalViewController: HealthNavigationController, Alertable, UICollectio
         collectionView.backgroundColor = .clear
         collectionView.delegate = self
         collectionView.setCollectionViewLayout(createCollectionViewLayout(), animated: false)
+    }
+
+    func scrollToTop() {
+        guard isViewLoaded, collectionView != nil else { return }
+        collectionView.setContentOffset(.zero, animated: true)
     }
 
     private func navigateToChatbot() {


### PR DESCRIPTION
## 작업내용
- 현재 활성화된 탭을 한 번 더 탭하면 최상단으로 스크롤하는 기능을 추가했습니다. (프로필 탭 제외)
- 단, 캘린더 탭은 현재 월로 스크롤하도록 했습니다.
  - 기존에 캘린더 탭 진입시 현재 월로 스크롤하는 로직은 제거했습니다.
  - 그래서 네비 바에 버튼도 당장은 빼지 않았습니다.

## 테스트 영상
https://github.com/user-attachments/assets/f6087d24-64d7-43b5-9f6b-be773005579a

## 링크
- [노션 - QA](https://www.notion.so/oreumi/25aebaa8982b8042b8e2f77e77eb6d75?v=242ebaa8982b8158aea0000cba0038c6&source=copy_link)